### PR TITLE
Potential fix for code scanning alert no. 2: Use of password hash with insufficient computational effort

### DIFF
--- a/API/helpers/utils.js
+++ b/API/helpers/utils.js
@@ -9,8 +9,14 @@ import fs from 'fs';
 import FormData from 'form-data';
 
 export const encryptDecrypt = (action, data, apikey, secretkey) => {
-    const key = CryptoJS.SHA256(apikey); 
-    const iv = CryptoJS.enc.Utf8.parse(CryptoJS.SHA256(secretkey).toString(CryptoJS.enc.Hex).substring(0, 16)); 
+    const salt = CryptoJS.SHA256(`enc:${secretkey}`);
+    const derived = CryptoJS.PBKDF2(apikey, salt, {
+        keySize: 12, // 12 words = 48 bytes (32-byte key + 16-byte IV)
+        iterations: 100000,
+        hasher: CryptoJS.algo.SHA256
+    });
+    const key = CryptoJS.lib.WordArray.create(derived.words.slice(0, 8), 32);
+    const iv = CryptoJS.lib.WordArray.create(derived.words.slice(8, 12), 16);
 
     if (!['encrypt', 'decrypt'].includes(action)) {
         console.error("Invalid action. Use 'encrypt' or 'decrypt'.");
@@ -37,8 +43,14 @@ export const encryptDecrypt = (action, data, apikey, secretkey) => {
 };
 
 export const encryptDecryptPayout = (action, data, apikey, secretkey) => {
-    const key = CryptoJS.SHA256(apikey);
-    const iv = CryptoJS.enc.Utf8.parse(CryptoJS.SHA256(secretkey).toString(CryptoJS.enc.Hex).substring(0, 16));
+    const salt = CryptoJS.SHA256(`payout:${secretkey}`);
+    const derived = CryptoJS.PBKDF2(apikey, salt, {
+        keySize: 12, // 12 words = 48 bytes (32-byte key + 16-byte IV)
+        iterations: 100000,
+        hasher: CryptoJS.algo.SHA256
+    });
+    const key = CryptoJS.lib.WordArray.create(derived.words.slice(0, 8), 32);
+    const iv = CryptoJS.lib.WordArray.create(derived.words.slice(8, 12), 16);
 
     if (!['encrypt', 'decrypt'].includes(action)) {
         console.error("Invalid action. Use 'encrypt' or 'decrypt'.");


### PR DESCRIPTION
Potential fix for [https://github.com/prastowoardi/s88API/security/code-scanning/2](https://github.com/prastowoardi/s88API/security/code-scanning/2)

Use a slow KDF (PBKDF2) for key derivation instead of direct SHA-256.  
Best fix within provided code: in `API/helpers/utils.js`, replace both key/IV derivations in `encryptDecrypt` and `encryptDecryptPayout` with PBKDF2-derived material:

- Derive a 48-byte blob using PBKDF2 (`CryptoJS.PBKDF2`) from `apikey` with a salt derived from `secretkey`.
- Split into:
  - first 32 bytes (8 words) for AES-256 key
  - next 16 bytes (4 words) for IV
- Keep existing AES-CBC + PKCS7 + encode/decode behavior unchanged to minimize functional impact.

No changes are required in payout call sites because function signatures stay the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
