### PR TITLE
Potential fix for code scanning alert no. 2: Use of password hash with insufficient computational effort

### DIFF
--- a/API/helpers/utils.js
+++ b/API/helpers/utils.js
@@ -9,8 +9,16 @@ import fs from 'fs';
 import FormData from 'form-data';
 
 export const encryptDecrypt = (action, data, apikey, secretkey) => {
-    const key = CryptoJS.SHA256(apikey); 
-    const iv = CryptoJS.enc.Utf8.parse(CryptoJS.SHA256(secretkey).toString(CryptoJS.enc.Hex).substring(0, 16)); 
+    const PBKDF2_ITERATIONS = 100000;
+    const key = CryptoJS.PBKDF2(apikey, CryptoJS.enc.Utf8.parse(secretkey), {
+        keySize: 256 / 32,
+        iterations: PBKDF2_ITERATIONS,
+    });
+    const ivMaterial = CryptoJS.PBKDF2(secretkey, CryptoJS.enc.Utf8.parse(apikey), {
+        keySize: 128 / 32,
+        iterations: PBKDF2_ITERATIONS,
+    });
+    const iv = CryptoJS.lib.WordArray.create(ivMaterial.words.slice(0, 4), 16);
 
     if (!['encrypt', 'decrypt'].includes(action)) {
         console.error("Invalid action. Use 'encrypt' or 'decrypt'.");
@@ -37,8 +45,16 @@ export const encryptDecrypt = (action, data, apikey, secretkey) => {
 };
 
 export const encryptDecryptPayout = (action, data, apikey, secretkey) => {
-    const key = CryptoJS.SHA256(apikey);
-    const iv = CryptoJS.enc.Utf8.parse(CryptoJS.SHA256(secretkey).toString(CryptoJS.enc.Hex).substring(0, 16));
+    const PBKDF2_ITERATIONS = 100000;
+    const key = CryptoJS.PBKDF2(apikey, CryptoJS.enc.Utf8.parse(secretkey), {
+        keySize: 256 / 32,
+        iterations: PBKDF2_ITERATIONS,
+    });
+    const ivMaterial = CryptoJS.PBKDF2(secretkey, CryptoJS.enc.Utf8.parse(apikey), {
+        keySize: 128 / 32,
+        iterations: PBKDF2_ITERATIONS,
+    });
+    const iv = CryptoJS.lib.WordArray.create(ivMaterial.words.slice(0, 4), 16);
 
     if (!['encrypt', 'decrypt'].includes(action)) {
         console.error("Invalid action. Use 'encrypt' or 'decrypt'.");


### PR DESCRIPTION
Potential fix for [https://github.com/prastowoardi/s88API/security/code-scanning/2](https://github.com/prastowoardi/s88API/security/code-scanning/2)

Use a password-based key derivation function (PBKDF2) instead of direct `SHA256(apikey)` to derive the AES key, and similarly derive IV bytes via PBKDF2 output (taking the first 16 bytes). This addresses the “insufficient computational effort” finding while keeping the same function signatures and encryption/decryption flow unchanged.

Best single fix in this codebase:
- Edit only `API/helpers/utils.js` in the two functions:
  - `encryptDecrypt`
  - `encryptDecryptPayout`
- Replace:
  - `const key = CryptoJS.SHA256(apikey);`
  - `const iv = CryptoJS.enc.Utf8.parse(CryptoJS.SHA256(secretkey)...substring(0,16));`
- With PBKDF2-based derivation using stable salts from existing inputs (`secretkey` and `apikey`) so no call-site changes are needed.
- Keep AES-CBC + PKCS7 and return formats as-is to avoid functional changes outside derivation strength.

Implementation details needed:
- No new imports required (PBKDF2 is available via `CryptoJS.PBKDF2`).
- Add local constants for iteration count and key sizes.
- Use `CryptoJS.PBKDF2(apikey, salt, { keySize: 256/32, iterations })` for key.
- Derive IV material with PBKDF2 and truncate to 16 bytes via `CryptoJS.lib.WordArray.create(ivMaterial.words.slice(0, 4), 16)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
