### PR TITLE
Potential fix for code scanning alert no. 70: Insecure randomness

### DIFF
--- a/API/helpers/utils.js
+++ b/API/helpers/utils.js
@@ -9,6 +9,7 @@ import CoinKey from 'coinkey';
 import axios from 'axios';
 import fs from 'fs';
 import FormData from 'form-data';
+import { randomInt } from 'crypto';
 
 export const encryptDecrypt = (action, data, apikey, secretkey, isJson = false) => {
     const key = CryptoJS.SHA256(apikey);
@@ -159,7 +160,7 @@ export function getAccountNumber(length = 8) {
     if (!Number.isInteger(length) || length <= 0) return '';
     let s = '';
     for (let i = 0; i < length; i++) {
-        s += Math.floor(Math.random() * 10); // 0..9
+        s += randomInt(0, 10); // 0..9 (cryptographically secure)
     }
     return s;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/prastowoardi/s88API/security/code-scanning/70](https://github.com/prastowoardi/s88API/security/code-scanning/70)

General fix: replace `Math.random()` for security-relevant value generation with Node.js cryptographically secure RNG (`crypto.randomInt`), and keep output format unchanged.

Best targeted fix without changing functionality:
- Edit **`API/helpers/utils.js`** in `getAccountNumber(length = 8)`.
- Import `randomInt` from Node’s `crypto` module.
- Replace per-digit generation from `Math.floor(Math.random() * 10)` to `randomInt(0, 10)` so each digit remains `0..9` but generated securely.
- Keep function signature/return type unchanged (still returns a numeric string of requested length, or empty string for invalid length).
- No behavior changes required in `API/PayBO/trx-deposit/paybo-depositV5.js`, since it already calls `getAccountNumber(5)` the same way.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
